### PR TITLE
Add support for RM4SC (and a derivative called KIX-code) barcodes

### DIFF
--- a/src/Barcoder/BarcodeType.cs
+++ b/src/Barcoder/BarcodeType.cs
@@ -14,5 +14,7 @@ namespace Barcoder
         public const string QR = "QR Code";
         public const string TwoOfFive = "2 of 5";
         public const string TwoOfFiveInterleaved = "2 of 5 (interleaved)";
+        public const string RM4SCC = "RM4SCC";
+        public const string KixCode = "KIX-code";
     }
 }

--- a/src/Barcoder/Rm4scc/ConstantsAndEnums.cs
+++ b/src/Barcoder/Rm4scc/ConstantsAndEnums.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace Barcoder.Rm4scc
+{
+    internal static class ConstantsAndEnums
+    {
+        internal static readonly BarTypes[][] Symbols = new BarTypes[][]
+        {
+            new [] { BarTypes.Tracker, BarTypes.Tracker, BarTypes.FullHeight, BarTypes.FullHeight }, // 0
+		    new [] { BarTypes.Tracker, BarTypes.Descender, BarTypes.Ascender, BarTypes.FullHeight }, // 1
+		    new [] { BarTypes.Tracker, BarTypes.Descender, BarTypes.FullHeight, BarTypes.Ascender }, // 2
+		    new [] { BarTypes.Descender, BarTypes.Tracker, BarTypes.Ascender, BarTypes.FullHeight }, // 3
+		    new [] { BarTypes.Descender, BarTypes.Tracker, BarTypes.FullHeight, BarTypes.Ascender }, // 4
+		    new [] { BarTypes.Descender, BarTypes.Descender, BarTypes.Ascender, BarTypes.Ascender }, // 5
+		    new [] { BarTypes.Tracker, BarTypes.Ascender, BarTypes.Descender, BarTypes.FullHeight }, // 6
+		    new [] { BarTypes.Tracker, BarTypes.FullHeight, BarTypes.Tracker, BarTypes.FullHeight }, // 7
+		    new [] { BarTypes.Tracker, BarTypes.FullHeight, BarTypes.Descender, BarTypes.Ascender }, // 8
+		    new [] { BarTypes.Descender, BarTypes.Ascender, BarTypes.Tracker, BarTypes.FullHeight }, // 9
+		    new [] { BarTypes.Descender, BarTypes.Ascender, BarTypes.Descender, BarTypes.Ascender }, // A
+		    new [] { BarTypes.Descender, BarTypes.FullHeight, BarTypes.Tracker, BarTypes.Ascender }, // B
+		    new [] { BarTypes.Tracker, BarTypes.Ascender, BarTypes.FullHeight, BarTypes.Descender }, // C
+		    new [] { BarTypes.Tracker, BarTypes.FullHeight, BarTypes.Ascender, BarTypes.Descender }, // D
+		    new [] { BarTypes.Tracker, BarTypes.FullHeight, BarTypes.FullHeight, BarTypes.Tracker }, // E
+		    new [] { BarTypes.Descender, BarTypes.Ascender, BarTypes.Ascender, BarTypes.Descender }, // F
+		    new [] { BarTypes.Descender, BarTypes.Ascender, BarTypes.FullHeight, BarTypes.Tracker }, // G
+		    new [] { BarTypes.Descender, BarTypes.FullHeight, BarTypes.Ascender, BarTypes.Tracker }, // H
+		    new [] { BarTypes.Ascender, BarTypes.Tracker, BarTypes.Descender, BarTypes.FullHeight }, // I
+		    new [] { BarTypes.Ascender, BarTypes.Descender, BarTypes.Tracker, BarTypes.FullHeight }, // J
+		    new [] { BarTypes.Ascender, BarTypes.Descender, BarTypes.Descender, BarTypes.Ascender }, // K
+		    new [] { BarTypes.FullHeight, BarTypes.Tracker, BarTypes.Tracker, BarTypes.FullHeight }, // L
+		    new [] { BarTypes.FullHeight, BarTypes.Tracker, BarTypes.Descender, BarTypes.Ascender }, // M
+		    new [] { BarTypes.FullHeight, BarTypes.Descender, BarTypes.Tracker, BarTypes.Ascender }, // N
+		    new [] { BarTypes.Ascender, BarTypes.Tracker, BarTypes.FullHeight, BarTypes.Descender }, // O
+		    new [] { BarTypes.Ascender, BarTypes.Descender, BarTypes.Ascender, BarTypes.Descender }, // P
+		    new [] { BarTypes.Ascender, BarTypes.Descender, BarTypes.FullHeight, BarTypes.Tracker }, // Q
+		    new [] { BarTypes.FullHeight, BarTypes.Tracker, BarTypes.Ascender, BarTypes.Descender }, // R
+		    new [] { BarTypes.FullHeight, BarTypes.Tracker, BarTypes.FullHeight, BarTypes.Tracker }, // S
+		    new [] { BarTypes.FullHeight, BarTypes.Descender, BarTypes.Ascender, BarTypes.Tracker }, // T
+		    new [] { BarTypes.Ascender, BarTypes.Ascender, BarTypes.Descender, BarTypes.Descender }, // U
+		    new [] { BarTypes.Ascender, BarTypes.FullHeight, BarTypes.Tracker, BarTypes.Descender }, // V
+		    new [] { BarTypes.Ascender, BarTypes.FullHeight, BarTypes.Descender, BarTypes.Tracker }, // W
+		    new [] { BarTypes.FullHeight, BarTypes.Ascender, BarTypes.Tracker, BarTypes.Descender }, // X
+		    new [] { BarTypes.FullHeight, BarTypes.Ascender, BarTypes.Descender, BarTypes.Tracker }, // Y
+		    new [] { BarTypes.FullHeight, BarTypes.FullHeight, BarTypes.Tracker, BarTypes.Tracker }, // Z
+        };
+    }
+
+    [Flags]
+    internal enum BarTypes
+    {
+        Tracker = 0,
+        Ascender = 1,
+        Descender = 2,
+        FullHeight = 3
+    }
+}

--- a/src/Barcoder/Rm4scc/Rm4sccCode.cs
+++ b/src/Barcoder/Rm4scc/Rm4sccCode.cs
@@ -1,0 +1,31 @@
+using Barcoder.Utils;
+
+namespace Barcoder.Rm4scc
+{
+    public sealed class Rm4sccCode : IBarcode
+    {
+        private readonly BitList _data;
+
+        private readonly int _width;
+
+        private const int HEIGHT = 8;
+
+        internal Rm4sccCode(BitList data, int width, bool isKixCode)
+        {
+            Metadata = new Metadata(isKixCode ? BarcodeType.KixCode : BarcodeType.RM4SCC, 2);
+            _data = data;
+            _width = width;
+            Bounds = new Bounds(width, HEIGHT);
+        }
+
+        public string Content { get; internal set; }
+
+        public Bounds Bounds { get; }
+
+        public int Margin => 8;
+
+        public Metadata Metadata { get; }
+
+        public bool At(int x, int y) => _data.GetBit(y * _width + x);
+    }
+}

--- a/src/Barcoder/Rm4scc/Rm4sccEncoder.cs
+++ b/src/Barcoder/Rm4scc/Rm4sccEncoder.cs
@@ -1,0 +1,113 @@
+using System;
+using Barcoder.Utils;
+using System.Collections.Generic;
+
+namespace Barcoder.Rm4scc
+{
+    public static class Rm4sccEncoder
+    {
+        private const int BARCODE_HEIGHT = 8;
+
+        public static IBarcode Encode(string content, bool encodeAsKix = false)
+        {
+            // Determine barcode length
+            var nBars = content.Length * 4;
+            if (!encodeAsKix)
+                nBars += 6; // start, checksum, stop
+            var barcodeWidth = nBars * 2 - 1;
+            var bitlist = new BitList(barcodeWidth * BARCODE_HEIGHT);
+
+            var i = 0;
+
+            // Start bar
+            if (!encodeAsKix)
+            {
+                SetBar(BarTypes.Ascender, bitlist, i, barcodeWidth);
+                i += 2;
+            }
+
+            // Actual data
+            var codepointList = new List<int>(content.Length);
+            foreach (var c in content)
+            {
+                var codepointIndex = GetCodepointIndexFromChar(c);
+                codepointList.Add(codepointIndex);
+                SetCodepoint(codepointIndex, bitlist, i, barcodeWidth);
+                i += 8;
+            }
+
+            // Checksum and stop bar
+            if (!encodeAsKix)
+            {
+                int topHalf = 0, btmHalf = 0;
+                foreach (var c in codepointList)
+                {
+                    topHalf += ConstantsAndEnums.Symbols[c][0].HasFlag(BarTypes.Ascender) ? 4 : 0;
+                    topHalf += ConstantsAndEnums.Symbols[c][1].HasFlag(BarTypes.Ascender) ? 2 : 0;
+                    topHalf += ConstantsAndEnums.Symbols[c][2].HasFlag(BarTypes.Ascender) ? 1 : 0;
+                    topHalf += ConstantsAndEnums.Symbols[c][3].HasFlag(BarTypes.Ascender) ? 0 : 0;
+
+                    btmHalf += ConstantsAndEnums.Symbols[c][0].HasFlag(BarTypes.Descender) ? 4 : 0;
+                    btmHalf += ConstantsAndEnums.Symbols[c][1].HasFlag(BarTypes.Descender) ? 2 : 0;
+                    btmHalf += ConstantsAndEnums.Symbols[c][2].HasFlag(BarTypes.Descender) ? 1 : 0;
+                    btmHalf += ConstantsAndEnums.Symbols[c][3].HasFlag(BarTypes.Descender) ? 0 : 0;
+                }
+
+                // Find checksum 'character'
+                var topIdx = (topHalf % 6 == 0) ? 5 : (topHalf % 6 - 1);
+                var btmIdx = (btmHalf % 6 == 0) ? 5 : (btmHalf % 6 - 1);
+                var checkCpIndex = topIdx * 6 + btmIdx;
+                SetCodepoint(checkCpIndex, bitlist, i, barcodeWidth);
+                i += 8;
+
+                // Stop bar
+                SetBar(BarTypes.FullHeight, bitlist, i, barcodeWidth);
+            }
+
+            return new Rm4sccCode(bitlist, barcodeWidth, encodeAsKix);
+        }
+
+        private static int GetCodepointIndexFromChar(char character)
+        {
+            if (character >= '0' && character <= '9')
+                return character - '0';
+            else if (character >= 'A' && character <= 'Z')
+                return character - 'A' + 10;
+            else
+                throw new Exception($"Character 0x{(int)character:x2} is not supported by RM4SC encoding");
+        }
+
+        private static void SetCodepoint(int codepointIndex, BitList bitlist, int xStartPosition, int barcodeWidth)
+        {
+            var x = xStartPosition;
+            foreach (BarTypes barType in ConstantsAndEnums.Symbols[codepointIndex])
+            {
+                SetBar(barType, bitlist, x, barcodeWidth);
+                x += 2;
+            }
+        }
+
+        private static void SetBar(BarTypes bars, BitList bitlist, int xPosition, int barcodeWidth)
+        {
+            SetBit(bitlist, xPosition, 3, barcodeWidth);
+            SetBit(bitlist, xPosition, 4, barcodeWidth);
+            if (bars.HasFlag(BarTypes.Descender))
+            {
+                SetBit(bitlist, xPosition, 5, barcodeWidth);
+                SetBit(bitlist, xPosition, 6, barcodeWidth);
+                SetBit(bitlist, xPosition, 7, barcodeWidth);
+            }
+            if (bars.HasFlag(BarTypes.Ascender))
+            {
+                SetBit(bitlist, xPosition, 0, barcodeWidth);
+                SetBit(bitlist, xPosition, 1, barcodeWidth);
+                SetBit(bitlist, xPosition, 2, barcodeWidth);
+            }
+        }
+
+        private static void SetBit(this BitList bitlist, int x, int y, int barcodeWidth)
+        {
+            bitlist.SetBit(y * barcodeWidth + x, true);
+        }
+    }
+}

--- a/tests/Barcoder.Tests/Rm4scc/Rm4sccEncoderTests.cs
+++ b/tests/Barcoder.Tests/Rm4scc/Rm4sccEncoderTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Barcoder.Rm4scc;
+using FluentAssertions;
+using Xunit;
+
+namespace Barcoder.Tests.Rm4scc
+{
+    public sealed class Rm4sccEncoderTests
+    {
+        [Fact]
+        public void Encode_Barcoder_ShouldEncodeRm4sccCorrectly()
+        {
+            // Arrange
+            var content = "123ABC789XYZ"; // checksum character == 'K'
+            var expectedDataBits = ImageStringToBools(@"
+                +.....+.+.....+.+.....+.+...+...+...+...+...+.+.....+...+...+...+...+...+.+.+.....+.+.....+.+.....+.....+.+
+                +.....+.+.....+.+.....+.+...+...+...+...+...+.+.....+...+...+...+...+...+.+.+.....+.+.....+.+.....+.....+.+
+                +.....+.+.....+.+.....+.+...+...+...+...+...+.+.....+...+...+...+...+...+.+.+.....+.+.....+.+.....+.....+.+
+                +.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+
+                +.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+
+                ....+...+...+.+...+.....+.+...+...+.+.........+.+...+...+...+.+...+.....+.+.....+.+...+...+.+.......+.+...+
+                ....+...+...+.+...+.....+.+...+...+.+.........+.+...+...+...+.+...+.....+.+.....+.+...+...+.+.......+.+...+
+                ....+...+...+.+...+.....+.+...+...+.+.........+.+...+...+...+.+...+.....+.+.....+.+...+...+.+.......+.+...+
+            ");
+            var kixBits = ImageStringToBools(@"
+                ....+.+.....+.+.....+.+...+...+...+...+...+.+.....+...+...+...+...+...+.+.+.....+.+.....+.+....
+                ....+.+.....+.+.....+.+...+...+...+...+...+.+.....+...+...+...+...+...+.+.+.....+.+.....+.+....
+                ....+.+.....+.+.....+.+...+...+...+...+...+.+.....+...+...+...+...+...+.+.+.....+.+.....+.+....
+                +.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+
+                +.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+
+                ..+...+...+.+...+.....+.+...+...+.+.........+.+...+...+...+.+...+.....+.+.....+.+...+...+.+....
+                ..+...+...+.+...+.....+.+...+...+.+.........+.+...+...+...+.+...+.....+.+.....+.+...+...+.+....
+                ..+...+...+.+...+.....+.+...+...+.+.........+.+...+...+...+.+...+.....+.+.....+.+...+...+.+....
+            ");
+
+            // Act
+            IBarcode encoder = Rm4sccEncoder.Encode(content, encodeAsKix: false);
+
+            // Assert
+            encoder.Should().NotBeNull();
+            expectedDataBits.Length.Should().Be(encoder.Bounds.X * encoder.Bounds.Y);
+            for (int i = 0; i < expectedDataBits.Length; i++)
+            {
+                int x = i % encoder.Bounds.X;
+                int y = i / encoder.Bounds.X;
+                encoder.At(x, y).Should().Be(expectedDataBits[i], $"of expected bit on index {i}");
+            }
+        }
+
+        [Fact]
+        public void Encode_Barcoder_ShouldEncodeKixCorrectly()
+        {
+            // Arrange
+            var content = "123ABC789XYZ"; // checksum character == 'K'
+            var expectedDataBits = ImageStringToBools(@"
+                ....+.+.....+.+.....+.+...+...+...+...+...+.+.....+...+...+...+...+...+.+.+.....+.+.....+.+....
+                ....+.+.....+.+.....+.+...+...+...+...+...+.+.....+...+...+...+...+...+.+.+.....+.+.....+.+....
+                ....+.+.....+.+.....+.+...+...+...+...+...+.+.....+...+...+...+...+...+.+.+.....+.+.....+.+....
+                +.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+
+                +.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+.+
+                ..+...+...+.+...+.....+.+...+...+.+.........+.+...+...+...+.+...+.....+.+.....+.+...+...+.+....
+                ..+...+...+.+...+.....+.+...+...+.+.........+.+...+...+...+.+...+.....+.+.....+.+...+...+.+....
+                ..+...+...+.+...+.....+.+...+...+.+.........+.+...+...+...+.+...+.....+.+.....+.+...+...+.+....
+            ");
+
+            // Act
+            IBarcode encoder = Rm4sccEncoder.Encode(content, encodeAsKix: true);
+
+            // Assert
+            encoder.Should().NotBeNull();
+            expectedDataBits.Length.Should().Be(encoder.Bounds.X * encoder.Bounds.Y);
+            for (int i = 0; i < expectedDataBits.Length; i++)
+            {
+                int x = i % encoder.Bounds.X;
+                int y = i / encoder.Bounds.X;
+                encoder.At(x, y).Should().Be(expectedDataBits[i], $"of expected bit on index {i}");
+            }
+        }
+
+        private static bool[] ImageStringToBools(string imageString)
+        {
+            string[] lines = imageString?
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrEmpty(x))
+                .ToArray();
+
+            if ((lines?.Length ?? 0) <= 0)
+                throw new InvalidOperationException($"No data in {nameof(imageString)}");
+            var dimension = lines.First().Length;
+            foreach (var line in lines)
+                if (line.Length != dimension)
+                    throw new InvalidOperationException("Not all lines have the same length");
+            return lines.SelectMany(x => x).Select(x => x != '.').ToArray();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for RM4SCC barcodes which are used by Royal Mail.
Also this supports it's Dutch PostNL simplified derivative called KIX-code.

I added unit tests for both variants.