### PR TITLE
Add UPC A and E support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Supported Barcode Types:
 * PDF 417
 * QR Code
 * RM4SC (Royal Mail 4 State Code)
+* UPC A
+* UPC E
 
 ## NuGet package
 

--- a/src/Barcoder/BarcodeType.cs
+++ b/src/Barcoder/BarcodeType.cs
@@ -16,7 +16,7 @@ namespace Barcoder
         public const string TwoOfFiveInterleaved = "2 of 5 (interleaved)";
         public const string RM4SC = "RM4SC";
         public const string KixCode = "KIX-code";
-        public const string UPCA = "UPC-A";
-        public const string UPCE = "UPC-E";
+        public const string UPCA = "UPC A";
+        public const string UPCE = "UPC E";
     }
 }

--- a/src/Barcoder/BarcodeType.cs
+++ b/src/Barcoder/BarcodeType.cs
@@ -16,5 +16,7 @@ namespace Barcoder
         public const string TwoOfFiveInterleaved = "2 of 5 (interleaved)";
         public const string RM4SC = "RM4SC";
         public const string KixCode = "KIX-code";
+        public const string UPCA = "UPC-A";
+        public const string UPCE = "UPC-E";
     }
 }

--- a/src/Barcoder/UpcA/Constants.cs
+++ b/src/Barcoder/UpcA/Constants.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+
+namespace Barcoder.UpcA
+{
+    internal static class Constants
+    {
+        public static readonly IReadOnlyDictionary<char, EncodedNumber> EncodingTable = new Dictionary<char, EncodedNumber>
+        {
+            { '0', new EncodedNumber
+                {
+                    Left  = new[] {false, false, false, true, true, false, true},
+                    Right = new[] {true, true, true, false, false, true, false},
+                }
+            },
+            { '1', new EncodedNumber
+                {
+                    Left  = new[] {false, false, true, true, false, false, true},
+                    Right = new[] {true, true, false, false, true, true, false},
+                }
+            },
+            { '2', new EncodedNumber
+                {
+                    Left  = new[] {false, false, true, false, false, true, true},
+                    Right = new[] {true, true, false, true, true, false, false},
+                }
+            },
+            { '3', new EncodedNumber
+                {
+                    Left  = new[] {false, true, true, true, true, false, true},
+                    Right = new[] {true, false, false, false, false, true, false},
+                }
+            },
+            { '4', new EncodedNumber
+                {
+                    Left  = new[] {false, true, false, false, false, true, true},
+                    Right = new[] {true, false, true, true, true, false, false},
+                }
+            },
+            { '5', new EncodedNumber
+                {
+                    Left  = new[] {false, true, true, false, false, false, true},
+                    Right = new[] {true, false, false, true, true, true, false},
+                }
+            },
+            { '6', new EncodedNumber
+                {
+                    Left  = new[] {false, true, false, true, true, true, true},
+                    Right = new[] {true, false, true, false, false, false, false},
+                }
+            },
+            { '7', new EncodedNumber
+                {
+                    Left  = new[] {false, true, true, true, false, true, true},
+                    Right = new[] {true, false, false, false, true, false, false},
+                }
+            },
+            { '8', new EncodedNumber
+                {
+                    Left  = new[] {false, true, true, false, true, true, true},
+                    Right = new[] {true, false, false, true, false, false, false},
+                }
+            },
+            { '9', new EncodedNumber
+                {
+                    Left  = new[] {false, false, false, true, false, true, true},
+                    Right = new[] {true, true, true, false, true, false, false},
+                }
+            },
+        };
+
+        public struct EncodedNumber
+        {
+            public bool[] Left { get; set; }
+            public bool[] Right { get; set; }
+        }
+
+        public const int Margin = 10;
+    }
+}

--- a/src/Barcoder/UpcA/UpcAEncoder.cs
+++ b/src/Barcoder/UpcA/UpcAEncoder.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Barcoder.Utils;
+
+namespace Barcoder.UpcA
+{
+    public static class UpcAEncoder
+    {
+        public static IBarcode Encode(string content)
+        {
+            if (content == null) throw new ArgumentNullException(nameof(content));
+
+            if (!Regex.IsMatch(content, @"^[0-9]*$")) throw new InvalidOperationException("Can only encode numerical digits (0-9)");
+
+            var checksum = 0;
+            if (content.Length == 11)
+            {
+                char checksumChar = CalcChecksum(content);
+                content += checksumChar;
+                checksum = checksumChar - '0';
+            }
+            else if (content.Length == 12)
+            {
+                char checksumChar = CalcChecksum(content.Substring(0, content.Length - 1));
+                if (content[content.Length - 1] != checksumChar)
+                    throw new InvalidOperationException("Checksum mismatch");
+                checksum = checksumChar - '0';
+            }
+
+            if (content.Length == 12)
+            {
+                BitList result = EncodeUpcA(content);
+                return new Base1DCodeIntCS(result, BarcodeType.UPCA, content, checksum, Constants.Margin);
+            }
+
+            throw new InvalidOperationException("Invalid content length. Should be 11 if the code does not include a checksum, 12 if the code already includes a checksum");
+        }
+
+        private static BitList EncodeUpcA(string content)
+        {
+            var result = new BitList();
+
+            // Start bars
+            result.AddBit(true, false, true);
+
+            var cpos = 0;
+            foreach (var r in content)
+            {
+                Constants.EncodedNumber num = Constants.EncodingTable[r];
+                bool[] data = cpos < 6 ? num.Left : num.Right;
+
+                // Middle bars
+                if (cpos == 6)
+                    result.AddBit(false, true, false, true, false);
+
+                result.AddBit(data);
+                cpos++;
+            }
+
+            // Stop bars
+            result.AddBit(true, false, true);
+
+            return result;
+        }
+
+        private static char CalcChecksum(string content)
+        {
+            var numVals = content.Select(x => x - '0').ToArray(); // Convert UTF-16 string to array of numeric values
+            var result = 3 * (numVals[0] + numVals[2] + numVals[4] + numVals[6] + numVals[8] + numVals[10]);
+            result += numVals[1] + numVals[3] + numVals[5] + numVals[7] + numVals[9];
+            result %= 10;
+
+            result = result == 0 ? 0 : (10 - result);
+            return (char)(result + '0'); // Convert numeric value to UTF-16 value
+        }
+    }
+}

--- a/src/Barcoder/UpcE/Constants.cs
+++ b/src/Barcoder/UpcE/Constants.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+
+namespace Barcoder.UpcE
+{
+    internal static class Constants
+    {
+        public static readonly IReadOnlyDictionary<char, EncodedNumber> EncodingTable = new Dictionary<char, EncodedNumber>
+        {
+            { '0', new EncodedNumber
+                {
+                    Odd  = new[] {false, false, false, true, true, false, true},
+                    Even = new[] {false, true, false, false, true, true, true},
+                }
+            },
+            { '1', new EncodedNumber
+                {
+                    Odd  = new[] {false, false, true, true, false, false, true},
+                    Even = new[] {false, true, true, false, false, true, true},
+                }
+            },
+            { '2', new EncodedNumber
+                {
+                    Odd  = new[] {false, false, true, false, false, true, true},
+                    Even = new[] {false, false, true, true, false, true, true},
+                }
+            },
+            { '3', new EncodedNumber
+                {
+                    Odd  = new[] {false, true, true, true, true, false, true},
+                    Even = new[] {false, true, false, false, false, false, true},
+                }
+            },
+            { '4', new EncodedNumber
+                {
+                    Odd  = new[] {false, true, false, false, false, true, true},
+                    Even = new[] {false, false, true, true, true, false, true},
+                }
+            },
+            { '5', new EncodedNumber
+                {
+                    Odd  = new[] {false, true, true, false, false, false, true},
+                    Even = new[] {false, true, true, true, false, false, true},
+                }
+            },
+            { '6', new EncodedNumber
+                {
+                    Odd  = new[] {false, true, false, true, true, true, true},
+                    Even = new[] {false, false, false, false, true, false, true},
+                }
+            },
+            { '7', new EncodedNumber
+                {
+                    Odd  = new[] {false, true, true, true, false, true, true},
+                    Even = new[] {false, false, true, false, false, false, true},
+                }
+            },
+            { '8', new EncodedNumber
+                {
+                    Odd  = new[] {false, true, true, false, true, true, true},
+                    Even = new[] {false, false, false, true, false, false, true},
+                }
+            },
+            { '9', new EncodedNumber
+                {
+                    Odd  = new[] {false, false, false, true, false, true, true},
+                    Even = new[] {false, false, true, false, true, true, true},
+                }
+            },
+        };
+
+        public static readonly IReadOnlyDictionary<char, ParityPatterns> ParityPatternTable = new Dictionary<char, ParityPatterns>
+        {
+            { '0', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Even, Parity.Even, Parity.Odd, Parity.Odd, Parity.Odd},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Odd, Parity.Odd, Parity.Even, Parity.Even, Parity.Even},
+                }
+            },
+            { '1', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Even, Parity.Odd, Parity.Even, Parity.Odd, Parity.Odd},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Odd, Parity.Even, Parity.Odd, Parity.Even, Parity.Even},
+                }
+            },
+            { '2', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Even, Parity.Odd, Parity.Odd, Parity.Even, Parity.Odd},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Odd, Parity.Even, Parity.Even, Parity.Odd, Parity.Even},
+                }
+            },
+            { '3', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Even, Parity.Odd, Parity.Odd, Parity.Odd, Parity.Even},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Odd, Parity.Even, Parity.Even, Parity.Even, Parity.Odd},
+                }
+            },
+            { '4', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Odd, Parity.Even, Parity.Even, Parity.Odd, Parity.Odd},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Even, Parity.Odd, Parity.Odd, Parity.Even, Parity.Even},
+                }
+            },
+            { '5', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Odd, Parity.Odd, Parity.Even, Parity.Even, Parity.Odd},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Even, Parity.Even, Parity.Odd, Parity.Odd, Parity.Even},
+                }
+            },
+            { '6', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Odd, Parity.Odd, Parity.Odd, Parity.Even, Parity.Even},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Even, Parity.Even, Parity.Even, Parity.Odd, Parity.Odd},
+                }
+            },
+            { '7', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Odd, Parity.Even, Parity.Odd, Parity.Even, Parity.Odd},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Even, Parity.Odd, Parity.Even, Parity.Odd, Parity.Even},
+                }
+            },
+            { '8', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Odd, Parity.Even, Parity.Odd, Parity.Odd, Parity.Even},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Even, Parity.Odd, Parity.Even, Parity.Even, Parity.Odd},
+                }
+            },
+            { '9', new ParityPatterns
+                {
+                    NumberSystemZero = new[] {Parity.Even, Parity.Odd, Parity.Odd, Parity.Even, Parity.Odd, Parity.Even},
+                    NumberSystemOne  = new[] {Parity.Odd, Parity.Even, Parity.Even, Parity.Odd, Parity.Even, Parity.Odd},
+                }
+            },
+        };
+
+        public struct EncodedNumber
+        {
+            public bool[] Odd { get; set; }
+            public bool[] Even { get; set; }
+        }
+
+        public struct ParityPatterns
+        {
+            public Parity[] NumberSystemZero { get; set; }
+            public Parity[] NumberSystemOne { get; set; }
+        }
+
+        public enum Parity
+        {
+            Odd,
+            Even
+        }
+
+        public const int Margin = 10;
+    }
+
+    public enum UpcENumberSystem
+    {
+        Zero,
+        One
+    }
+}

--- a/src/Barcoder/UpcE/UpcEEncoder.cs
+++ b/src/Barcoder/UpcE/UpcEEncoder.cs
@@ -15,7 +15,7 @@ namespace Barcoder.UpcE
                 throw new InvalidOperationException("Can only encode numerical digits (0-9)");
 
             if (numberSystem != UpcENumberSystem.Zero && numberSystem != UpcENumberSystem.One)
-                throw new InvalidOperationException("Only number systems 0 and 1 are supported by UPC-E");
+                throw new InvalidOperationException("Only number systems 0 and 1 are supported by UPC E");
 
             if (content.Length != 6)
                 throw new InvalidOperationException("Invalid content length. Should be 6");

--- a/src/Barcoder/UpcE/UpcEEncoder.cs
+++ b/src/Barcoder/UpcE/UpcEEncoder.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Barcoder.Utils;
+
+namespace Barcoder.UpcE
+{
+    public static class UpcEEncoder
+    {
+        public static IBarcode Encode(string content, UpcENumberSystem numberSystem)
+        {
+            if (content == null) throw new ArgumentNullException(nameof(content));
+
+            if (!Regex.IsMatch(content, @"^[0-9]*$"))
+                throw new InvalidOperationException("Can only encode numerical digits (0-9)");
+
+            if (numberSystem != UpcENumberSystem.Zero && numberSystem != UpcENumberSystem.One)
+                throw new InvalidOperationException("Only number systems 0 and 1 are supported by UPC-E");
+
+            if (content.Length != 6)
+                throw new InvalidOperationException("Invalid content length. Should be 6");
+
+            BitList bitlist = EncodeUpcE(content, numberSystem);
+            return new Base1DCode(bitlist, BarcodeType.UPCE, content, Constants.Margin);
+        }
+
+        private static BitList EncodeUpcE(string content, UpcENumberSystem numberSystem)
+        {
+            var result = new BitList();
+
+            // Find the correct parity pattern
+            // To find it we need the check digit of the UPC-A for which this UPC-E barcode encodes
+            var upcA = GetUpcAFromUpcE(content, numberSystem);
+            var upcACheckDigit = upcA.Last();
+            Constants.ParityPatterns parityPatternTable = Constants.ParityPatternTable[upcACheckDigit];
+            Constants.Parity[] parityPattern = numberSystem == UpcENumberSystem.Zero ? 
+                parityPatternTable.NumberSystemZero : parityPatternTable.NumberSystemOne;
+
+            // Start bars
+            result.AddBit(true, false, true);
+            
+            // Data bars
+            for (int i = 0; i < content.Length; i++)
+            {
+                char c = content[i];
+                Constants.EncodedNumber num = Constants.EncodingTable[c];
+                Constants.Parity parity = parityPattern[i];
+
+                if (parity == Constants.Parity.Even)
+                    result.AddBit(num.Even);
+                else
+                    result.AddBit(num.Odd);
+            }
+
+            // Stop bars
+            result.AddBit(false, true, false, true, false, true);
+
+            return result;
+        }
+
+        private static string GetUpcAFromUpcE(string content, UpcENumberSystem numberSystem)
+        {
+            var firstChar = numberSystem == UpcENumberSystem.Zero ? '0' : '1';
+            var upcA = firstChar.ToString();
+
+            switch (content.Last())
+            {
+            case '0':
+            case '1':
+            case '2':
+                upcA += $"{content.Substring(0, 2)}{content.Last()}0000{content.Substring(2, 3)}";
+                break;
+            case '3':
+                upcA += $"{content.Substring(0, 3)}00000{content.Substring(3, 2)}";
+                break;
+            case '4':
+                upcA += $"{content.Substring(0, 4)}00000{content.Substring(4, 1)}";
+                break;
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                upcA += $"{content.Substring(0, 5)}0000{content.Last()}";
+                break;
+            }
+
+            upcA += CalculatedUpcAChecksum(upcA);
+            return upcA;
+        }
+
+        private static char CalculatedUpcAChecksum(string content)
+        {
+            var numVals = content.Select(x => x - '0').ToArray(); // Convert UTF-16 string to array of numeric values
+            var result = 3 * (numVals[0] + numVals[2] + numVals[4] + numVals[6] + numVals[8] + numVals[10]);
+            result += numVals[1] + numVals[3] + numVals[5] + numVals[7] + numVals[9];
+            result %= 10;
+
+            result = result == 0 ? 0 : (10 - result);
+            return (char)(result + '0'); // Convert numeric value to UTF-16 value
+        }
+    }
+}

--- a/tests/Barcoder.Tests/UpcA/UpcAEncoderTests.cs
+++ b/tests/Barcoder.Tests/UpcA/UpcAEncoderTests.cs
@@ -1,0 +1,56 @@
+using System;
+using Barcoder.UpcA;
+using FluentAssertions;
+using Xunit;
+
+namespace Barcoder.Tests.UpcA
+{
+    public sealed class UpcAEncoderTests
+    {
+        [Theory]
+        [InlineData("012345678912", "10100011010011001001001101111010100011011000101010101000010001001001000111010011001101101100101", BarcodeType.UPCA, true)]
+        [InlineData("01234567891", "10100011010011001001001101111010100011011000101010101000010001001001000111010011001101101100101", BarcodeType.UPCA, false)]
+        [InlineData("98765432109", "10100010110110111011101101011110110001010001101010100001011011001100110111001011101001001000101", BarcodeType.UPCA, false)]
+        public void Encode(string testCode, string testResult, string kind, bool checkContent)
+        {
+            IBarcode code = UpcAEncoder.Encode(testCode);
+            if (checkContent)
+                code.Content.Should().Be(testCode);
+
+            code.Bounds.X.Should().Be(testResult.Length);
+            code.Bounds.Y.Should().Be(1);
+            code.Metadata.CodeKind.Should().Be(kind);
+            code.Metadata.Dimensions.Should().Be(1);
+
+            string encoded = string.Empty;
+            int i = 0;
+            foreach (var r in testResult)
+                encoded += code.At(i++, 0) ? "1" : "0";
+            encoded.Should().Be(testResult);
+        }
+
+        [Fact]
+        public void Encode_InvalidChecksum_ShouldThrowException()
+        {
+            Action action = () => UpcAEncoder.Encode("012345678913");
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("Checksum mismatch");
+        }
+
+        [Fact]
+        public void Encode_InvalidCode_ShouldThrowException()
+        {
+            Action action = () => UpcAEncoder.Encode("invalid");
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("Can only encode numerical digits (0-9)");
+        }
+
+        [Fact]
+        public void Encode_InvalidContentLength_ShouldThrowException()
+        {
+            Action action = () => UpcAEncoder.Encode("123");
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("Invalid content length. Should be 11 if the code does not include a checksum, 12 if the code already includes a checksum");
+        }
+    }
+}

--- a/tests/Barcoder.Tests/UpcE/UpcEEncoderTests.cs
+++ b/tests/Barcoder.Tests/UpcE/UpcEEncoderTests.cs
@@ -45,7 +45,7 @@ namespace Barcoder.Tests.UpcE
         {
             Action action = () => UpcEEncoder.Encode("654321", (UpcENumberSystem)2);
             action.Should().Throw<InvalidOperationException>()
-                .WithMessage("Only number systems 0 and 1 are supported by UPC-E");
+                .WithMessage("Only number systems 0 and 1 are supported by UPC E");
         }
 
         [Fact]

--- a/tests/Barcoder.Tests/UpcE/UpcEEncoderTests.cs
+++ b/tests/Barcoder.Tests/UpcE/UpcEEncoderTests.cs
@@ -1,0 +1,63 @@
+using System;
+using Barcoder.UpcE;
+using FluentAssertions;
+using Xunit;
+
+namespace Barcoder.Tests.UpcE
+{
+    public sealed class UpcEEncoderTests
+    {
+        [Theory]
+        [InlineData("654321", UpcENumberSystem.Zero, "101000010101100010011101011110100110110011001010101", BarcodeType.UPCE)]
+        [InlineData("654321", UpcENumberSystem.One, "101010111101110010100011011110100110110110011010101", BarcodeType.UPCE)]
+        [InlineData("123456", UpcENumberSystem.Zero, "101011001100100110111101001110101110010101111010101", BarcodeType.UPCE)]
+        public void Encode(string testCode, UpcENumberSystem numberSystem, string testResult, string kind)
+        {
+            IBarcode code = UpcEEncoder.Encode(testCode, numberSystem);
+            code.Content.Should().Be(testCode);
+
+            code.Bounds.X.Should().Be(testResult.Length);
+            code.Bounds.Y.Should().Be(1);
+            code.Metadata.CodeKind.Should().Be(kind);
+            code.Metadata.Dimensions.Should().Be(1);
+
+            string encoded = string.Empty;
+            int i = 0;
+            foreach (var r in testResult)
+                encoded += code.At(i++, 0) ? "1" : "0";
+            encoded.Should().Be(testResult);
+        }
+
+        [Fact]
+        public void Encode_InvalidCode_ShouldThrowException()
+        {
+            Action action = () => UpcEEncoder.Encode("invalid", UpcENumberSystem.Zero);
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("Can only encode numerical digits (0-9)");
+
+            Action action2 = () => UpcEEncoder.Encode("invalid", UpcENumberSystem.One);
+            action2.Should().Throw<InvalidOperationException>()
+                .WithMessage("Can only encode numerical digits (0-9)");
+        }
+
+        [Fact]
+        public void Encode_InvalidNumberSystem_ShouldThrowException()
+        {
+            Action action = () => UpcEEncoder.Encode("654321", (UpcENumberSystem)2);
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("Only number systems 0 and 1 are supported by UPC-E");
+        }
+
+        [Fact]
+        public void Encode_InvalidContentLength_ShouldThrowException()
+        {
+            Action action = () => UpcEEncoder.Encode("123", UpcENumberSystem.Zero);
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("Invalid content length. Should be 6");
+
+            Action action2 = () => UpcEEncoder.Encode("123", UpcENumberSystem.One);
+            action2.Should().Throw<InvalidOperationException>()
+                .WithMessage("Invalid content length. Should be 6");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the two most commonly used UPC barcodes. As UPC A is very similar to EAN 13, it's code could make use of the existing EAN 13 support ("Don't Repeat Yourself") but I decided to implement it as a separate symbology for the following reasons:

- Using the existing EAN 13 code could make the UPC A encoder throw exceptions which are specific to EAN 13 (this could confuse both developers and end users)
- The UPC A encoding scheme is a lot simpler than the EAN 13 encoding scheme, any bugs in the EAN 13 implementation are ruled out this way and I think the code is more clear this way (less cyclomatic complexity, UpcAEncoder code easy to follow)

Let me know your thoughts on this, I can of course adapt the code to use the existing EAN 13 implementation :)