### PR TITLE
allow customizing bar code colors

### DIFF
--- a/src/Barcoder.Renderer.Image/ImageRendererSettings.cs
+++ b/src/Barcoder.Renderer.Image/ImageRendererSettings.cs
@@ -1,0 +1,16 @@
+﻿using SixLabors.ImageSharp.PixelFormats;
+
+namespace Barcoder.Renderer.Image
+{
+    public class ImageRendererSettings<TPixel> where TPixel : struct, IPixel<TPixel>
+    {
+        public int PixelSize { get; set; } = 10;
+        public int BarHeightFor1DBarcode { get; set; } = 40;
+        public ImageFormat ImageFormat { get; set; } = ImageFormat.Png;
+        public int JpegQuality { get; set; } = 75;
+        public bool IncludeEanContentAsText { get; set; }
+        public string EanFontFamily { get; set; } = "Arial";
+        public TPixel BackgroundColor { get; set; } = NamedColors<TPixel>.White;
+        public TPixel ForegroundColor { get; set; } = NamedColors<TPixel>.Black;
+    }
+}

--- a/src/Barcoder.Renderer.Image/Internal/EanContentRenderer.cs
+++ b/src/Barcoder.Renderer.Image/Internal/EanContentRenderer.cs
@@ -7,13 +7,13 @@ using SixLabors.Primitives;
 
 namespace Barcoder.Renderer.Image.Internal
 {
-    internal static class EanContentRenderer
+    internal static class EanContentRenderer<TPixel> where TPixel: struct, IPixel<TPixel>
     {
         private const int UnscaledFontSize = 9;
         private const int ContentMargin = 9;
         private const int ContentVerticalOffset = 0;
 
-        public static void Render(Image<Gray8> image, IBarcode barcode, string fontFamily, int scale)
+        public static void Render(Image<TPixel> image, IBarcode barcode, string fontFamily, int scale)
         {
             Font font = SystemFonts.CreateFont(fontFamily, UnscaledFontSize * scale, FontStyle.Regular);
 
@@ -28,7 +28,7 @@ namespace Barcoder.Renderer.Image.Internal
             }
         }
 
-        private static void RenderContentForEan8(Image<Gray8> image, string content, Font font, int margin, int scale)
+        private static void RenderContentForEan8(Image<TPixel> image, string content, Font font, int margin, int scale)
         {
             int ApplyScale(int value) => value * scale;
             RenderWhiteRect(image, ApplyScale(margin + 3), image.Height - ApplyScale(margin + ContentMargin), ApplyScale(29), ApplyScale(ContentMargin));
@@ -41,7 +41,7 @@ namespace Barcoder.Renderer.Image.Internal
             RenderBlackText(image, content.Substring(4), textCenter2, textTop, font);
         }
 
-        private static void RenderContentForEan13(Image<Gray8> image, string content, Font font, int margin, int scale)
+        private static void RenderContentForEan13(Image<TPixel> image, string content, Font font, int margin, int scale)
         {
             int ApplyScale(int value) => value * scale;
             RenderWhiteRect(image, ApplyScale(margin + 3), image.Height - ApplyScale(margin + ContentMargin), ApplyScale(43), ApplyScale(ContentMargin));
@@ -56,17 +56,17 @@ namespace Barcoder.Renderer.Image.Internal
             RenderBlackText(image, content.Substring(7), textCenter3, textTop, font);
         }
 
-        private static void RenderWhiteRect(Image<Gray8> image, int x, int y, int width, int height)
+        private static void RenderWhiteRect(Image<TPixel> image, int x, int y, int width, int height)
         {
             image.Mutate(ctx => ctx.FillPolygon(
-                NamedColors<Gray8>.White,
+                NamedColors<TPixel>.White,
                 new Vector2(x, y),
                 new Vector2(x + width, y),
                 new Vector2(x + width, y + height),
                 new Vector2(x, y + height)));
         }
 
-        private static void RenderBlackText(Image<Gray8> image, string text, float x, float y, Font font)
+        private static void RenderBlackText(Image<TPixel> image, string text, float x, float y, Font font)
         {
             var options = new TextGraphicsOptions
             {
@@ -74,7 +74,7 @@ namespace Barcoder.Renderer.Image.Internal
                 VerticalAlignment = VerticalAlignment.Center,
             };
 
-            image.Mutate(ctx => ctx.DrawText(options, text, font, NamedColors<Gray8>.Black, new PointF(x, y)));
+            image.Mutate(ctx => ctx.DrawText(options, text, font, NamedColors<TPixel>.Black, new PointF(x, y)));
         }
     }
 }

--- a/tests/Barcoder.Renderer.Image.Tests/ImageRendererTests.cs
+++ b/tests/Barcoder.Renderer.Image.Tests/ImageRendererTests.cs
@@ -7,6 +7,7 @@ using Barcoder.Renderers;
 using FluentAssertions;
 using Moq;
 using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 using ImageSharp = SixLabors.ImageSharp;
 
@@ -18,7 +19,7 @@ namespace Barcoder.Renderer.Image.Tests
         public void Render_PassNullAsBarcode_ShouldThrowException()
         {
             // Arrange
-            var renderer = new ImageRenderer();
+            var renderer = new ImageRenderer<Gray8>();
             var stream = new MemoryStream();
 
             // Act
@@ -33,7 +34,7 @@ namespace Barcoder.Renderer.Image.Tests
         public void Render_PassNullAsOutputStream_ShouldThrowException()
         {
             // Arrange
-            var renderer = new ImageRenderer();
+            var renderer = new ImageRenderer<Gray8>();
             var barcodeMock = new Mock<IBarcode>();
 
             // Act
@@ -48,7 +49,7 @@ namespace Barcoder.Renderer.Image.Tests
         public void Render_Barcode1D()
         {
             // Arrange
-            var renderer = new ImageRenderer();
+            var renderer = new ImageRenderer<Gray8>();
             IBarcode barcode = Code128Encoder.Encode("Wikipedia");
 
             // Act
@@ -62,7 +63,7 @@ namespace Barcoder.Renderer.Image.Tests
         public void Render_Barcode2D()
         {
             // Arrange
-            var renderer = new ImageRenderer();
+            var renderer = new ImageRenderer<Gray8>();
             IBarcode barcode = QrEncoder.Encode("Hello Unicode\nHave a nice day!", ErrorCorrectionLevel.L, Encoding.Unicode);
 
             // Act
@@ -76,7 +77,7 @@ namespace Barcoder.Renderer.Image.Tests
         public void Render_ImageFormatBmp_ShouldRenderBmp()
         {
             // Arrange
-            var renderer = new ImageRenderer(imageFormat: ImageFormat.Bmp);
+            var renderer = new ImageRenderer<Gray8>(imageFormat: ImageFormat.Bmp);
             IBarcode barcode = QrEncoder.Encode("Hello", ErrorCorrectionLevel.L, Encoding.Unicode);
             using var stream = new MemoryStream();
 
@@ -93,7 +94,7 @@ namespace Barcoder.Renderer.Image.Tests
         public void Render_ImageFormatGif_ShouldRenderGif()
         {
             // Arrange
-            var renderer = new ImageRenderer(imageFormat: ImageFormat.Gif);
+            var renderer = new ImageRenderer<Gray8>(imageFormat: ImageFormat.Gif);
             IBarcode barcode = QrEncoder.Encode("Hello", ErrorCorrectionLevel.L, Encoding.Unicode);
             using var stream = new MemoryStream();
 
@@ -110,7 +111,7 @@ namespace Barcoder.Renderer.Image.Tests
         public void Render_ImageFormatJpeg_ShouldRenderJpeg()
         {
             // Arrange
-            var renderer = new ImageRenderer(imageFormat: ImageFormat.Jpeg);
+            var renderer = new ImageRenderer<Gray8>(imageFormat: ImageFormat.Jpeg);
             IBarcode barcode = QrEncoder.Encode("Hello", ErrorCorrectionLevel.L, Encoding.Unicode);
             using var stream = new MemoryStream();
 
@@ -127,7 +128,7 @@ namespace Barcoder.Renderer.Image.Tests
         public void Render_ImageFormatPng_ShouldRenderPng()
         {
             // Arrange
-            var renderer = new ImageRenderer(imageFormat: ImageFormat.Png);
+            var renderer = new ImageRenderer<Gray8>(imageFormat: ImageFormat.Png);
             IBarcode barcode = QrEncoder.Encode("Hello", ErrorCorrectionLevel.L, Encoding.Unicode);
             using var stream = new MemoryStream();
 
@@ -150,7 +151,7 @@ namespace Barcoder.Renderer.Image.Tests
         [Fact(Skip = "Integration test")]
         public void Render_Ean8_IncludeContentAsText()
         {
-            var renderer = new ImageRenderer(imageFormat: ImageFormat.Png, includeEanContentAsText: true);
+            var renderer = new ImageRenderer<Gray8>(imageFormat: ImageFormat.Png, includeEanContentAsText: true);
             IBarcode barcode = EanEncoder.Encode("1234567");
             using Stream stream = File.OpenWrite(@"d:\temp\ean-test.png");
             renderer.Render(barcode, stream);
@@ -159,7 +160,7 @@ namespace Barcoder.Renderer.Image.Tests
         [Fact(Skip = "Integration test")]
         public void Render_Ean13_IncludeContentAsText()
         {
-            var renderer = new ImageRenderer(imageFormat: ImageFormat.Png, includeEanContentAsText: true);
+            var renderer = new ImageRenderer<Gray8>(imageFormat: ImageFormat.Png, includeEanContentAsText: true);
             IBarcode barcode = EanEncoder.Encode("978020137962");
             using Stream stream = File.OpenWrite(@"d:\temp\ean-test.png");
             renderer.Render(barcode, stream);


### PR DESCRIPTION
This PR adds the ability to customize the colors of the barcode.

At my job, we have an industrial printer that has bizarre (to my mind) color requirements. To print on this device, different bits of content need to use very specific colors.

This PR enables the developer to specify foreground and background colors for the printed barcodes, by passing options to `Barcoder.Renderer.Image.ImageRenderer`.

In case there's a performance concern, rather than forcing all images to be `Rgba32`, or `Rgb24`, the developer can request the pixel format of the `ImageRenderer`, for example:

```c#
var rgb24Renderer = new ImageRenderer<Rgb24>(10, 40, ImageFormat.Jpeg, 100);
var gray8Renderer = new ImageRenderer<Gray8>(10, 40);
```

Additionally, rather than make the existing `ImageRenderer` constructor definition even longer, it has been left alone, and a second constructor has been added, which accepts a new `ImageRendererSettings` object:

```c#
var renderer = new ImageRenderer<Rgb24>(new() {
    ImageFormat = ImageFormat.Png,
    BackgroundColor = new Rgb24(0, 169, 233),
    ForegroundColor = new Rgb24(233, 0, 0)
});
```

(If using an older version of C#, you may need to type out the full `new ImageRendererSettings<Rgb24>()`.)

The `ImageRendererSettings` properties have the same defaults as the original constructor and `ImageRenderer` behavior, including black and white colors.