### PR TITLE
upgraded `SixLabors.ImageSharp.Drawing` to latest version

### DIFF
--- a/src/Barcoder.Renderer.Image/Barcoder.Renderer.Image.csproj
+++ b/src/Barcoder.Renderer.Image/Barcoder.Renderer.Image.csproj
@@ -6,7 +6,7 @@
     <Description>Image Renderer for Barcoder (.NET Framework, .NET Standard and .NET Core).</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Wouter Huysentruit</Company>
-    <Version>1.0.0-beta0006</Version>
+    <Version>1.0.0-beta13</Version>
     <Authors>Wouter Huysentruit</Authors>
     <PackageProjectUrl>https://github.com/huysentruitw/barcoder</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0006" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Barcoder.Renderer.Image/ImageRenderer.cs
+++ b/src/Barcoder.Renderer.Image/ImageRenderer.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Barcoder.Renderer.Image.Internal;
 using Barcoder.Renderers;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Gif;
@@ -71,17 +72,17 @@ namespace Barcoder.Renderer.Image
             int width = (barcode.Bounds.X + 2 * barcode.Margin) * _pixelSize;
             int height = (_barHeightFor1DBarcode + 2 * barcode.Margin) * _pixelSize;
 
-            using (var image = new Image<Gray8>(width, height))
+            using (var image = new Image<Rgb24>(width, height))
             {
                 image.Mutate(ctx =>
                 {
-                    ctx.Fill(NamedColors<Gray8>.White);
+                    ctx.Fill(Color.White);
                     for (var x = 0; x < barcode.Bounds.X; x++)
                     {
                         if (!barcode.At(x, 0))
                             continue;
                         ctx.FillPolygon(
-                            NamedColors<Gray8>.Black,
+                            Color.Black,
                             new Vector2((barcode.Margin + x) * _pixelSize, barcode.Margin * _pixelSize),
                             new Vector2((barcode.Margin + x + 1) * _pixelSize, barcode.Margin * _pixelSize),
                             new Vector2((barcode.Margin + x + 1) * _pixelSize, (_barHeightFor1DBarcode + barcode.Margin) * _pixelSize),
@@ -101,18 +102,18 @@ namespace Barcoder.Renderer.Image
             int width = (barcode.Bounds.X + 2 * barcode.Margin) * _pixelSize;
             int height = (barcode.Bounds.Y + 2 * barcode.Margin) * _pixelSize;
 
-            using (var image = new Image<Gray8>(width, height))
+            using (var image = new Image<Rgb24>(width, height))
             {
                 image.Mutate(ctx =>
                 {
-                    ctx.Fill(NamedColors<Gray8>.White);
+                    ctx.Fill(Color.White);
                     for (var y = 0; y < barcode.Bounds.Y; y++)
                     {
                         for (var x = 0; x < barcode.Bounds.X; x++)
                         {
                             if (!barcode.At(x, y)) continue;
                             ctx.FillPolygon(
-                                NamedColors<Gray8>.Black,
+                                Color.Black,
                                 new Vector2((barcode.Margin + x) * _pixelSize, (barcode.Margin + y) * _pixelSize),
                                 new Vector2((barcode.Margin + x + 1) * _pixelSize, (barcode.Margin + y) * _pixelSize),
                                 new Vector2((barcode.Margin + x + 1) * _pixelSize, (barcode.Margin + y + 1) * _pixelSize),

--- a/src/Barcoder.Renderer.Image/Internal/EanContentRenderer.cs
+++ b/src/Barcoder.Renderer.Image/Internal/EanContentRenderer.cs
@@ -1,9 +1,9 @@
 ﻿using System.Numerics;
 using SixLabors.Fonts;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.Primitives;
 
 namespace Barcoder.Renderer.Image.Internal
 {
@@ -13,7 +13,7 @@ namespace Barcoder.Renderer.Image.Internal
         private const int ContentMargin = 9;
         private const int ContentVerticalOffset = 0;
 
-        public static void Render(Image<Gray8> image, IBarcode barcode, string fontFamily, int scale)
+        public static void Render(Image<Rgb24> image, IBarcode barcode, string fontFamily, int scale)
         {
             Font font = SystemFonts.CreateFont(fontFamily, UnscaledFontSize * scale, FontStyle.Regular);
 
@@ -28,7 +28,7 @@ namespace Barcoder.Renderer.Image.Internal
             }
         }
 
-        private static void RenderContentForEan8(Image<Gray8> image, string content, Font font, int margin, int scale)
+        private static void RenderContentForEan8(Image<Rgb24> image, string content, Font font, int margin, int scale)
         {
             int ApplyScale(int value) => value * scale;
             RenderWhiteRect(image, ApplyScale(margin + 3), image.Height - ApplyScale(margin + ContentMargin), ApplyScale(29), ApplyScale(ContentMargin));
@@ -41,7 +41,7 @@ namespace Barcoder.Renderer.Image.Internal
             RenderBlackText(image, content.Substring(4), textCenter2, textTop, font);
         }
 
-        private static void RenderContentForEan13(Image<Gray8> image, string content, Font font, int margin, int scale)
+        private static void RenderContentForEan13(Image<Rgb24> image, string content, Font font, int margin, int scale)
         {
             int ApplyScale(int value) => value * scale;
             RenderWhiteRect(image, ApplyScale(margin + 3), image.Height - ApplyScale(margin + ContentMargin), ApplyScale(43), ApplyScale(ContentMargin));
@@ -56,25 +56,28 @@ namespace Barcoder.Renderer.Image.Internal
             RenderBlackText(image, content.Substring(7), textCenter3, textTop, font);
         }
 
-        private static void RenderWhiteRect(Image<Gray8> image, int x, int y, int width, int height)
+        private static void RenderWhiteRect(Image<Rgb24> image, int x, int y, int width, int height)
         {
             image.Mutate(ctx => ctx.FillPolygon(
-                NamedColors<Gray8>.White,
+                Color.White,
                 new Vector2(x, y),
                 new Vector2(x + width, y),
                 new Vector2(x + width, y + height),
                 new Vector2(x, y + height)));
         }
 
-        private static void RenderBlackText(Image<Gray8> image, string text, float x, float y, Font font)
+        private static void RenderBlackText(Image<Rgb24> image, string text, float x, float y, Font font)
         {
-            var options = new TextGraphicsOptions
+            var options = new DrawingOptions()
             {
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
+                TextOptions = new TextOptions()
+                {
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                }
             };
 
-            image.Mutate(ctx => ctx.DrawText(options, text, font, NamedColors<Gray8>.Black, new PointF(x, y)));
+            image.Mutate(ctx => ctx.DrawText(options, text, font, Color.Black, new PointF(x, y)));
         }
     }
 }

--- a/tests/Barcoder.Renderer.Image.Tests/Barcoder.Renderer.Image.Tests.csproj
+++ b/tests/Barcoder.Renderer.Image.Tests/Barcoder.Renderer.Image.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0006" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
in the latest version of `SixLabors.ImageSharp.Drawing`, `TPixel` has been simplified, `TextOptions` have changed slightly, `NamedColors<T>` has been removed, and `Gray8` has been removed (I replaced its usage with `Rgb24`)