### PR TITLE
Upgraded ImageSharp

### DIFF
--- a/src/Barcoder.Renderer.Image/Barcoder.Renderer.Image.csproj
+++ b/src/Barcoder.Renderer.Image/Barcoder.Renderer.Image.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Barcoder.Renderer.Image.Tests/Barcoder.Renderer.Image.Tests.csproj
+++ b/tests/Barcoder.Renderer.Image.Tests/Barcoder.Renderer.Image.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="6.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Barcoder.Renderer.Image.Tests/ImageRendererTests.cs
+++ b/tests/Barcoder.Renderer.Image.Tests/ImageRendererTests.cs
@@ -140,6 +140,23 @@ namespace Barcoder.Renderer.Image.Tests
             imageFormat.Name.Should().Be("PNG");
         }
 
+        [Fact]
+        public void Render_Image_ShouldRender()
+        {
+            // Arrange
+            var renderer = new ImageRenderer(new ImageRendererOptions { ImageFormat = ImageFormat.Png });
+            IBarcode barcode = QrEncoder.Encode("Hello", ErrorCorrectionLevel.L, Encoding.Unicode);
+
+            // Act
+            var image = renderer.Render(barcode);
+
+            // Assert
+            image.Frames.Count.Should().Be(1);
+            image.Width.Should().Be(310);
+            image.Height.Should().Be(310);
+            image.PixelType.BitsPerPixel.Should().Be(8);
+        }
+
         private static byte[] RenderBarcodeToByteArray(IRenderer renderer, IBarcode barcode)
         {
             using var stream = new MemoryStream();


### PR DESCRIPTION
* Upgraded ImageSharp to latest to fix `MissingMethodException` when run in a project using a newer version of ImageSharp.
* Added ability to expose the ImageSharp image without rendering to an image format. Shouldn't have to encode as a PNG and decode it to work with it after.