### PR TITLE
Add 1D barcode height and EAN font family for SVG renderer

### DIFF
--- a/src/Barcoder.Renderer.Svg/SvgRenderer.cs
+++ b/src/Barcoder.Renderer.Svg/SvgRenderer.cs
@@ -118,14 +118,14 @@ namespace Barcoder.Renderer.Svg
             {
                 if (barcode.Metadata.CodeKind == BarcodeType.EAN13)
                 {
-                    AddText(document, 4, height + 0.5D, barcode.Content.Substring(0, 1));
-                    AddText(document, 21, height + 0.5D, barcode.Content.Substring(1, 6));
-                    AddText(document, 67, height + 0.5D, barcode.Content.Substring(7));
+                    AddText(document, 4, height - 0.5D, barcode.Content.Substring(0, 1));
+                    AddText(document, 21, height - 0.5D, barcode.Content.Substring(1, 6));
+                    AddText(document, 67, height - 0.5D, barcode.Content.Substring(7));
                 }
                 else
                 {
-                    AddText(document, 18, height + 0.5D, barcode.Content.Substring(0, 4));
-                    AddText(document, 50, height + 0.5D, barcode.Content.Substring(4));
+                    AddText(document, 18, height - 0.5D, barcode.Content.Substring(0, 4));
+                    AddText(document, 50, height - 0.5D, barcode.Content.Substring(4));
                 }
             }
 

--- a/src/Barcoder.Renderer.Svg/SvgRenderer.cs
+++ b/src/Barcoder.Renderer.Svg/SvgRenderer.cs
@@ -135,7 +135,7 @@ namespace Barcoder.Renderer.Svg
         private void AddText(SvgDocument doc, double x, double y, string t)
         {
             SvgText text = doc.AddText();
-            text.FontFamily = _options.EanFontFamily;
+            text.FontFamily = _options.EanFontFamily ?? throw new ArgumentNullException(nameof(_options.EanFontFamily));
             text.Text = t;
             text.X = x;
             text.Y = y;

--- a/src/Barcoder.Renderer.Svg/SvgRendererOptions.cs
+++ b/src/Barcoder.Renderer.Svg/SvgRendererOptions.cs
@@ -3,7 +3,11 @@
     public sealed class SvgRendererOptions
     {
         public bool IncludeEanContentAsText { get; set; } = false;
-        
+
         public int? CustomMargin { get; set; } = null;
+
+        public int BarHeightFor1DBarcode { get; set; } = 50;
+
+        public string EanFontFamily { get; set; } = "Arial";
     }
 }

--- a/src/Barcoder.Renderer.Svg/SvgRendererOptions.cs
+++ b/src/Barcoder.Renderer.Svg/SvgRendererOptions.cs
@@ -8,6 +8,6 @@
 
         public int BarHeightFor1DBarcode { get; set; } = 50;
 
-        public string EanFontFamily { get; set; } = "Arial";
+        public string EanFontFamily { get; set; } = "arial";
     }
 }


### PR DESCRIPTION
Result

|                               | EAN8 | EAN13 | CODE128 |
|----------------------|------|-------|---------|
| 15px no text                 |   ![EAN 9031101 - 15px - Times New Roman font - incl text False ](https://github.com/huysentruitw/barcoder/assets/21057595/bdce72d8-5f3b-4a6d-a95f-b80789db2740)   |    ![EAN 978020137962 - 15px - Arial font - incl text False ](https://github.com/huysentruitw/barcoder/assets/21057595/54ffd929-2ca3-4823-8f8c-2be50a1f8475)   |    ![CODE 128 9031101 - 15px](https://github.com/huysentruitw/barcoder/assets/21057595/6950ac70-19c9-47a3-b0e0-47743e0817d3)     |
| 50 px no text                |   ![EAN 9031101 - 50px - Arial font - incl text False ](https://github.com/huysentruitw/barcoder/assets/21057595/8c801dfb-8709-4c48-9505-f8b7714ff1f7)   |    ![EAN 978020137962 - 50px - Arial font - incl text False ](https://github.com/huysentruitw/barcoder/assets/21057595/12bb3d50-943e-45dc-977e-38ab1d429528)   |    ![CODE 128 9031101 - 50px](https://github.com/huysentruitw/barcoder/assets/21057595/f6f8eb7a-7d4a-47c5-a33a-f70ab63bb0d1)     |
| 15px Arial                     |   ![EAN 9031101 - 15px - Arial font - incl text True ](https://github.com/huysentruitw/barcoder/assets/21057595/150e8713-663e-4997-b600-6827cbbf9d1f)   |    ![EAN 978020137962 - 15px - Arial font - incl text True ](https://github.com/huysentruitw/barcoder/assets/21057595/6dadd1a0-ee17-4257-9df2-9505d68c28ae)  |   |   nbsp;      |
| 50px Times New Roman |   ![EAN 9031101 - 50px - Times New Roman font - incl text True ](https://github.com/huysentruitw/barcoder/assets/21057595/627d42c2-1ae1-40d6-8485-83f7e4e6bed5)   |   ![EAN 978020137962 - 50px - Times New Roman font - incl text True ](https://github.com/huysentruitw/barcoder/assets/21057595/fa2837da-d7c9-4727-a1c8-35a697cdaa58)   |        |


